### PR TITLE
Changed the message property type of Roggle.log() from `Object' to 'Object?'

### DIFF
--- a/lib/src/roggle.dart
+++ b/lib/src/roggle.dart
@@ -56,39 +56,39 @@ class Roggle {
   bool get active => _active;
 
   /// Log a message at level [Level.verbose].
-  void v(Object message, [Object? error, StackTrace? stackTrace]) {
+  void v(Object? message, [Object? error, StackTrace? stackTrace]) {
     log(Level.verbose, message, error, stackTrace);
   }
 
   /// Log a message at level [Level.debug].
-  void d(Object message, [Object? error, StackTrace? stackTrace]) {
+  void d(Object? message, [Object? error, StackTrace? stackTrace]) {
     log(Level.debug, message, error, stackTrace);
   }
 
   /// Log a message at level [Level.info].
-  void i(Object message, [Object? error, StackTrace? stackTrace]) {
+  void i(Object? message, [Object? error, StackTrace? stackTrace]) {
     log(Level.info, message, error, stackTrace);
   }
 
   /// Log a message at level [Level.warning].
-  void w(Object message, [Object? error, StackTrace? stackTrace]) {
+  void w(Object? message, [Object? error, StackTrace? stackTrace]) {
     log(Level.warning, message, error, stackTrace);
   }
 
   /// Log a message at level [Level.error].
-  void e(Object message, [Object? error, StackTrace? stackTrace]) {
+  void e(Object? message, [Object? error, StackTrace? stackTrace]) {
     log(Level.error, message, error, stackTrace);
   }
 
   /// Log a message at level [Level.wtf].
-  void wtf(Object message, [Object? error, StackTrace? stackTrace]) {
+  void wtf(Object? message, [Object? error, StackTrace? stackTrace]) {
     log(Level.wtf, message, error, stackTrace);
   }
 
   /// Log a message with [level].
   void log(
     Level level,
-    Object message, [
+    Object? message, [
     Object? error,
     StackTrace? stackTrace,
   ]) {

--- a/test/roggle_test.dart
+++ b/test/roggle_test.dart
@@ -91,6 +91,12 @@ void main() {
       expect(printedError, null);
       expect(printedStackTrace, null);
 
+      logger.log(level, null);
+      expect(printedLevel, level);
+      expect(printedMessage, null);
+      expect(printedError, null);
+      expect(printedStackTrace, null);
+
       message = Random().nextInt(999999999).toString();
       logger.log(level, message, 'MyError');
       expect(printedLevel, level);
@@ -129,6 +135,12 @@ void main() {
     expect(printedMessage, 'Test');
     expect(printedError, 'Error');
     expect(printedStackTrace, stackTrace);
+
+    logger.v(null);
+    expect(printedLevel, Level.verbose);
+    expect(printedMessage, null);
+    expect(printedError, null);
+    expect(printedStackTrace, null);
   });
 
   test('Roggle.d', () {
@@ -139,6 +151,12 @@ void main() {
     expect(printedMessage, 'Test');
     expect(printedError, 'Error');
     expect(printedStackTrace, stackTrace);
+
+    logger.d(null);
+    expect(printedLevel, Level.debug);
+    expect(printedMessage, null);
+    expect(printedError, null);
+    expect(printedStackTrace, null);
   });
 
   test('Roggle.i', () {
@@ -149,6 +167,12 @@ void main() {
     expect(printedMessage, 'Test');
     expect(printedError, 'Error');
     expect(printedStackTrace, stackTrace);
+
+    logger.i(null);
+    expect(printedLevel, Level.info);
+    expect(printedMessage, null);
+    expect(printedError, null);
+    expect(printedStackTrace, null);
   });
 
   test('Roggle.w', () {
@@ -159,6 +183,12 @@ void main() {
     expect(printedMessage, 'Test');
     expect(printedError, 'Error');
     expect(printedStackTrace, stackTrace);
+
+    logger.w(null);
+    expect(printedLevel, Level.warning);
+    expect(printedMessage, null);
+    expect(printedError, null);
+    expect(printedStackTrace, null);
   });
 
   test('Roggle.e', () {
@@ -169,6 +199,12 @@ void main() {
     expect(printedMessage, 'Test');
     expect(printedError, 'Error');
     expect(printedStackTrace, stackTrace);
+
+    logger.e(null);
+    expect(printedLevel, Level.error);
+    expect(printedMessage, null);
+    expect(printedError, null);
+    expect(printedStackTrace, null);
   });
 
   test('Roggle.wtf', () {
@@ -179,6 +215,12 @@ void main() {
     expect(printedMessage, 'Test');
     expect(printedError, 'Error');
     expect(printedStackTrace, stackTrace);
+
+    logger.wtf(null);
+    expect(printedLevel, Level.wtf);
+    expect(printedMessage, null);
+    expect(printedError, null);
+    expect(printedStackTrace, null);
   });
 
   test('setting log level above log level of message', () {


### PR DESCRIPTION
Issue #9